### PR TITLE
Make package title a link as well on CustomCard

### DIFF
--- a/src/components/CustomCard.tsx
+++ b/src/components/CustomCard.tsx
@@ -45,9 +45,12 @@ export default function CustomCard(props: { item: Repo; program: boolean }) {
         src={props.item.avatar_url}
         alt={props.item.name}
       />
-      <h5 className="text-2xl font-bold text-gray-900 dark:text-white">
+      <a
+        href={(props.program ? "" : "packages/") + props.item.full_name}
+        className="text-2xl font-bold text-gray-900 dark:text-white"
+      >
         {props.item.name}
-      </h5>
+      </a>
       <p className="text-gray-400">{props.item.full_name}</p>
       <div className="flex space-x-3">
         {props.item.archived ? (
@@ -120,9 +123,7 @@ export default function CustomCard(props: { item: Repo; program: boolean }) {
         )}
       </div>
       <Button
-        href={
-          (props.program ? "" : "packages/") + props.item.full_name
-        }
+        href={(props.program ? "" : "packages/") + props.item.full_name}
         color="light"
         pill
       >


### PR DESCRIPTION
If this is too forward, feel free to shut it down. It just felt more natural for me to click on the title than to move my mouse to the button. I thought it a small UX improvement to the cards.

My prettier caught a bit of formatting lower down. I ran the formatter afterwards and it touched a lot, so I just left this single one, but I can remove that if you'd prefer. 
