### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   update-submodule:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/Zigistry/Zigistry/security/code-scanning/6](https://github.com/Zigistry/Zigistry/security/code-scanning/6)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the permissions required for the workflow to function correctly. Since the workflow involves pushing changes to the repository, it requires `contents: write` permissions. We will set this at the job level to limit the scope of the permissions to the `update-submodule` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
